### PR TITLE
Bdist wheel universal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
+#  - "3.2"  # py.test has no support for Python 3.2
   - "3.3"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev" # 3.7 development branch
+  - "nightly" # currently points to 3.7-dev
+  - "pypy"
 install:
   - pip install -r requirements_test.txt
   - pip install coveralls

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ test: test_install
 	@py.test --cov-report term-missing --cov=deprecated
 
 upload:
-	@python setup.py sdist upload
+	@python setup.py sdist bdist_wheel upload

--- a/deprecated/__init__.py
+++ b/deprecated/__init__.py
@@ -15,7 +15,7 @@ def deprecated(func):
     def new_func(*args, **kwargs):
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(
-            "Call to deprecated function {}.".format(func.__name__),
+            "Call to deprecated function {0}.".format(func.__name__),
             category=DeprecationWarning,
             stacklevel=2
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal=1
+
 [pytest]
 python_files=test*.py
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,65 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+u"""
+Python-Deprecated
+-----------------
 
-from setuptools import setup, find_packages
+Python ``@deprecated`` decorator to deprecate old python functions or methods.
+
+Deprecated is Easy to Use
+`````````````````````````
+
+If you need to mark a function or a method as deprecated,
+you can use the ``@deprecated`` decorator:
+
+Save in a hello.py:
+
+.. code:: python
+
+    from deprecated import deprecated
+
+
+    @deprecated
+    def some_old_function(x, y):
+        return x + y
+
+
+    class SomeClass(object):
+        @deprecated
+        def some_old_method(self, x, y):
+            return x + y
+
+
+    some_old_function(12, 34)
+    obj = SomeClass()
+    obj.some_old_method(5, 8)
+
+
+And Easy to Setup
+`````````````````
+
+And run it:
+
+.. code:: bash
+
+    $ pip install Python-Deprecated
+    $ python hello.py
+    hello.py:15: DeprecationWarning: Call to deprecated function some_old_function.
+      some_old_function(12, 34)
+    hello.py:17: DeprecationWarning: Call to deprecated function some_old_method.
+      obj.some_old_method(5, 8)
+
+
+Links
+`````
+
+* `website <https://github.com/vrcmarcos/python-deprecated>`_
+* `StackOverFlow Question <http://stackoverflow.com/questions/2536307>`_
+* `development version
+  <https://github.com/vrcmarcos/python-deprecated/zipball/master#egg=Python-Deprecated-dev>`_
+
+"""
+from setuptools import setup
 
 setup(
     name='Python-Deprecated',
@@ -10,13 +69,16 @@ setup(
     author='Marcos Cardoso',
     author_email='vrcmarcos@gmail.com',
     description='Python Deprecated Decorator',
-    packages=find_packages(),
+    long_description=__doc__,
+    packages=['deprecated'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',
     classifiers=[
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,14 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )


### PR DESCRIPTION
The Python-Deprecated project can be distributed as an [universal Wheel](https://packaging.python.org/tutorials/distributing-packages/#universal-wheels).

> The Python-Deprecated project lack of a long description. This documentation is important to have a good visibility on the [Python Package Index](https://pypi.python.org/pypi/Python-Deprecated/1.0.0) and the future [Warehouse](https://pypi.org/project/Python-Deprecated/#description).
> 
> This pull request will add the following:
> 
> - A long description: How to use, how to setup, Links.
> - A more complete list of classifiers.
> - An improve Travis configuration to test the script from Python 2.6 to Python 3.7-dev, and PyPy.
> - A small fix for Python 2.6 compatibility.
> 
> Regards
> – Laurent.